### PR TITLE
Changes for moving bmctl, sa as part of preflight..Done some var upda…

### DIFF
--- a/tools/anthosbm-ansible-module/create_anthos_cluster.yml
+++ b/tools/anthosbm-ansible-module/create_anthos_cluster.yml
@@ -37,24 +37,22 @@
   vars_files:
     - "vars/anthos_vars_{{ cluster_type }}.yml"
   roles:
-    - role: ws-docker
-      become: yes
-      become_method: sudo
-      tags: [never,docker]
-    - role: gcloud-sdk
-      become: yes
-      become_method: sudo
-      tags: [never,gcloud]
-    - role: kubectl-tool
-      become: yes
-      become_method: sudo
-      tags: [kubectl]
-    - role: bmctl-tool
-      become: yes
-      become_method: sudo
-      tags: [bmctl]
-    - role: service-accounts
-      tags: [never,sa,serviceaccount]
+    # - role: ws-docker
+    #   become: yes
+    #   become_method: sudo
+    #   tags: [never,docker]
+    # - role: gcloud-sdk
+    #   become: yes
+    #   become_method: sudo
+    #   tags: [never,gcloud]
+    # - role: kubectl-tool
+    #   become: yes
+    #   become_method: sudo
+    #   tags: [kubectl]
+    # - role: bmctl-tool
+    #   become: yes
+    #   become_method: sudo
+    #   tags: [bmctl]
     - role: anthos
       tags: [anthos]
     - role: connect-gateway

--- a/tools/anthosbm-ansible-module/roles/reset-cluster/tasks/main.yml
+++ b/tools/anthosbm-ansible-module/roles/reset-cluster/tasks/main.yml
@@ -16,7 +16,7 @@
   shell:
     cmd: "bmctl reset cluster -c {{ cluster_name }}"
     chdir: "{{ login_user_home }}"
-  when: cluster_type == "hybrid"
+  when: cluster_type != "user"
 
 - name: Reset User Cluster
   shell:

--- a/tools/anthosbm-ansible-module/roles/update-cluster/tasks/main.yml
+++ b/tools/anthosbm-ansible-module/roles/update-cluster/tasks/main.yml
@@ -19,7 +19,14 @@
     owner: "{{ login_user }}"
     group: "{{ login_user_group }}"
 
-- name: Update Cluster
+- name: Update admin/hybrid Cluster
   shell:
-    cmd: "bmctl update cluster -c {{ cluster_name }} --kubeconfig {{ bmctl_workspace_dir }}/{{ cluster_name }}/{{ cluster_name }}-kubeconfig"
+    cmd: "bmctl update cluster -c {{ cluster_name }} --kubeconfig {{ admin_kubeconfig_path }}"
     chdir: "{{ login_user_home }}"
+  when: cluster_type != "user" 
+
+- name: Update user Cluster
+  shell:
+    cmd: "bmctl update cluster -c {{ cluster_name }} --admin-kubeconfig {{ admin_kubeconfig_path }}"
+    chdir: "{{ login_user_home }}"
+  when: cluster_type == "user"  

--- a/tools/anthosbm-ansible-module/roles/upgrade-cluster/tasks/main.yml
+++ b/tools/anthosbm-ansible-module/roles/upgrade-cluster/tasks/main.yml
@@ -21,5 +21,5 @@
 
 - name: Upgrade Anthos Cluster Version
   shell:
-    cmd: "bmctl upgrade cluster -c {{ cluster_name }} --kubeconfig {{ bmctl_workspace_dir }}/{{ cluster_name }}/{{ cluster_name }}-kubeconfig --bootstrap-cluster-pod-cidr={{ pod_cidr }} --bootstrap-cluster-service-cidr={{ service_cidr }}"
+    cmd: "bmctl upgrade cluster -c {{ cluster_name }} --kubeconfig {{ admin_kubeconfig_path }} --bootstrap-cluster-pod-cidr={{ kind_pod_cidr }} --bootstrap-cluster-service-cidr={{ kind_service_cidr }}"
     chdir: "{{ login_user_home }}"

--- a/tools/anthosbm-ansible-module/vars/anthos_vars_hybrid.yml
+++ b/tools/anthosbm-ansible-module/vars/anthos_vars_hybrid.yml
@@ -24,10 +24,13 @@ bmctl_download_url: gs://anthos-baremetal-release/bmctl/1.9.2/linux-amd64/bmctl
 bmctl_workspace_dir: bmctl-workspace
 gcp_sa_key_dir: "{{ login_user_home }}/gcp_keys"
 gcloud_preq_sa_name: anthos-preq-gcloud-svc-account
-local_gcr_sa_name: anthos-gcr-svc-account
-local_connect_agent_sa_name: connect-agent-svc-account
-local_connect_register_sa_name: register-svc-account
-local_cloud_operations_sa_name: cloud-ops-svc-account
+
+
+## Dont need the service account name.Its being taken care by bmctl
+# local_gcr_sa_name: anthos-gcr-svc-account
+# local_connect_agent_sa_name: connect-agent-svc-account
+# local_connect_register_sa_name: register-svc-account
+# local_cloud_operations_sa_name: cloud-ops-svc-account
 
 node_login_user: anthos
 
@@ -35,6 +38,7 @@ node_login_user: anthos
 kind_pod_cidr: 192.168.0.0/16
 kind_service_cidr: 10.96.0.0/12
 
+# ssh key path to access control plane and worker nodes
 ssh_private_key_path: "{{ login_user_home }}/.ssh/id_rsa"
 # the GCP project ID
 project_id: PROJECT_ID
@@ -60,9 +64,8 @@ lb_mode: bundled
 ingress_vip: 10.200.0.48
 lb_address_pool: 
 - 10.200.0.48/28
-# For a 'user' cluster, place the admin cluster kubeconfig file on workstation machine 
-# and set admin_kubeconfig_path to the absolute path of this file
-admin_kubeconfig_path: 
+# For Hybrid/Admin cluster this file is the default path to the cluster kubeconfig file
+admin_kubeconfig_path: {{ bmctl_workspace_dir }}/{{ cluster_name }}/{{ cluster_name }}-kubeconfig
 # list of users or service accounts that will be connect gateway members
 cgw_members: 
 - user:EXAMPLE_USERNAME@google.com

--- a/tools/anthosbm-ansible-module/vars/anthos_vars_user.yml
+++ b/tools/anthosbm-ansible-module/vars/anthos_vars_user.yml
@@ -24,10 +24,12 @@ bmctl_download_url: gs://anthos-baremetal-release/bmctl/1.9.2/linux-amd64/bmctl
 bmctl_workspace_dir: bmctl-workspace
 gcp_sa_key_dir: "{{ login_user_home }}/gcp_keys"
 gcloud_preq_sa_name: anthos-preq-gcloud-svc-account
-local_gcr_sa_name: anthos-gcr-svc-account
-local_connect_agent_sa_name: connect-agent-svc-account
-local_connect_register_sa_name: register-svc-account
-local_cloud_operations_sa_name: cloud-ops-svc-account
+
+## Dont need the service account name.Its being taken care by bmctl
+# local_gcr_sa_name: anthos-gcr-svc-account
+# local_connect_agent_sa_name: connect-agent-svc-account
+# local_connect_register_sa_name: register-svc-account
+# local_cloud_operations_sa_name: cloud-ops-svc-account
 
 
 node_login_user: anthos
@@ -36,6 +38,7 @@ node_login_user: anthos
 kind_pod_cidr: 192.168.0.0/16
 kind_service_cidr: 10.96.0.0/12
 
+# ssh key path to access control plane and worker nodes
 ssh_private_key_path: "{{ login_user_home }}/.ssh/id_rsa"
 # the GCP project ID
 project_id: PROJECT_ID
@@ -61,7 +64,8 @@ lb_mode: bundled
 ingress_vip: 10.200.0.48
 lb_address_pool: 
 - 10.200.0.48/28
-# For a 'user' cluster, place the admin cluster kubeconfig file on workstation machine 
+
+# For a 'user' cluster, place the admin/hybrid cluster kubeconfig file on workstation machine 
 # and set admin_kubeconfig_path to the absolute path of this file
 admin_kubeconfig_path: 
 # list of users or service accounts that will be connect gateway members

--- a/tools/anthosbm-ansible-module/workstation_preflight.yml
+++ b/tools/anthosbm-ansible-module/workstation_preflight.yml
@@ -16,8 +16,8 @@
 - hosts: workstation
 #  remote_user: "{{ login_user }}"
   gather_facts: "yes"
-#  vars_files:
-#    - "vars/anthos_vars_{{ cluster_type }}.yml"
+ vars_files:
+   - "vars/anthos_vars_{{ cluster_type }}.yml"
   roles:
     - role: workstation-preflight
       become: yes
@@ -26,8 +26,18 @@
     - role: ws-docker
       become: yes
       become_method: sudo
-      tags: [never,install-docker]
+      tags: [install-docker]
     - role: gcloud-sdk
       become: yes
       become_method: sudo
-      tags: [never,install-gcloud]
+      tags: [install-gcloud]
+    - role: kubectl-tool
+      become: yes
+      become_method: sudo
+      tags: [kubectl] 
+    - role: bmctl-tool
+      become: yes
+      become_method: sudo
+      tags: [bmctl]  
+    - role: service-accounts
+      tags: [sa,serviceaccount]  


### PR DESCRIPTION
I looked into the idea of not having to pass the cluster_type env variable. But It will really makes things more complex..I mean I will have to create different roles for hybrid and user for create cluster. Will need two different playbooks for create, update and may be reset. I am not sure if thats the right way to go.We can discuss tomorrow on this..
I have also moved the bmctl install and Service account creation in the preflight and the create cluster just runs Anthos related stuff but with that we might also have to pass the env variable for running preflight playbook. 
We can definitely talk more and surely look more into these changes..
